### PR TITLE
scene number debug overlay for Morth

### DIFF
--- a/game/screens.rpy
+++ b/game/screens.rpy
@@ -202,6 +202,25 @@ style quick_right_button_text:
     xalign 1.0
 
 ##########################################
+##-------------SCENE_NUMBER-------------##
+##########################################
+
+# Scene number is used for debugging to show the current scene.
+
+screen scene_number(act_scene):
+    frame:
+        at mmfade(0)
+        xpos 200
+        xsize 280
+        background Solid(gui.box_background_color)
+        label _(act_scene):
+            text_ycenter 0.73 # This aligns the text to the bottom of the container. Ack.
+            text_size 90
+            xcenter 0.5
+            yanchor 1.0
+            ypos 180
+
+##########################################
 ##-------------NAVIGATION--------------##
 ##########################################
 

--- a/game/scripts/a1/A1_01.rpy
+++ b/game/scripts/a1/A1_01.rpy
@@ -1,4 +1,6 @@
 label A1_01:
+    show screen scene_number("A1_01")
+    
     stop music
     $ queue_music(music_one)
     $ crossfade_music(0.0, 1.0, 0.0)

--- a/game/scripts/a1/A1_02.rpy
+++ b/game/scripts/a1/A1_02.rpy
@@ -1,4 +1,5 @@
 label A1_02:
+    show screen scene_number("A1_02")
     # TODO: Add Long Time Skip here.
     scene bg_back_alley with Dissolve(1.5)
     $ queue_music(placeholder)

--- a/game/scripts/a1/A1_03.rpy
+++ b/game/scripts/a1/A1_03.rpy
@@ -1,4 +1,5 @@
 label A1_03:
+    show screen scene_number("A1_03")
     # TODO: Add Long Time Skip here.
     show bg_black
     "Pulling the car back into the alleyway behind Arcady feels like sinking through molasses into another world."

--- a/game/scripts/a1/A1_04.rpy
+++ b/game/scripts/a1/A1_04.rpy
@@ -1,4 +1,5 @@
 ﻿label A1_04:
+    show screen scene_number("A1_04")
     # TODO: Add Long Time Skip here.
     scene bg_club_2_during_work with Dissolve(0.5)
     $ queue_music(music_four1)

--- a/game/scripts/a1/A1_05.rpy
+++ b/game/scripts/a1/A1_05.rpy
@@ -1,4 +1,5 @@
 ﻿label A1_05:
+    show screen scene_number("A1_05")
     scene bg_club_2_after_work with Dissolve (1.0)
     $ queue_music(music_five)
     "After an hour or so of mindless busy-work that does nothing to lift my mood, I decide I need a break."

--- a/game/scripts/a1/A1_07c.rpy
+++ b/game/scripts/a1/A1_07c.rpy
@@ -1,4 +1,5 @@
 ﻿label A1_07c:
+    show screen scene_number("A1_07c")
     # TODO: Add Long Time Skip here.
     scene bg_club_2_before_work with Dissolve(0.5)
     "After that, the days seemed to just pass me by."

--- a/game/scripts/a1/A1_07r.rpy
+++ b/game/scripts/a1/A1_07r.rpy
@@ -1,4 +1,5 @@
 ﻿label A1_07r:
+    show screen scene_number("A1_07r")
     scene bg_black with Dissolve(0.5)
     "After that, the days just kept... passing."
     "Sounds like a bit of a no brainer, but I guess it just goes to show how much energy I've put into that stupid bet with Eris."

--- a/game/scripts/a1/A1_08c.rpy
+++ b/game/scripts/a1/A1_08c.rpy
@@ -1,4 +1,5 @@
 ﻿label A1_08c:
+    show screen scene_number("A1_08c")
     # TODO: Add Long Time Skip here.
     scene bg_club_2_before_work with Dissolve(0.5)
     $ queue_music(placeholder)

--- a/game/scripts/a1/A1_08r.rpy
+++ b/game/scripts/a1/A1_08r.rpy
@@ -1,4 +1,5 @@
 ﻿label A1_08r: 
+    show screen scene_number("A1_08r")
     scene bg_black with Dissolve(0.5)
     $ queue_music(placeholder)
     "If the last few weeks were a blur, the one that follows them is more like white noise."

--- a/game/scripts/a1/A1_09c.rpy
+++ b/game/scripts/a1/A1_09c.rpy
@@ -1,4 +1,5 @@
 ﻿label A1_09c:
+    show screen scene_number("A1_09c")
     # TODO: Add Long Time Skip here.
     scene bg_black with Dissolve(0.5)
     play audio car_engine

--- a/game/scripts/a1/A1_09r.rpy
+++ b/game/scripts/a1/A1_09r.rpy
@@ -1,4 +1,5 @@
 ﻿label A1_09r:
+    show screen scene_number("A1_09r")
     scene bg_club_2_during_work with Dissolve(0.5)
     "The hours kept running like wax."
     "Eris's big upgrade couldn't have taken that long, but there you had it. I'd taken my eyes off the clock and the next time I knew it, minutes all added up into months."


### PR DESCRIPTION
- what it says on the tin: show the current act and scene in the top right-hand corner.
- displays overlay on the screen layer during main gameplay that is hidden during menus.